### PR TITLE
Avoid discarding jobs on SIGTERM

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -19,6 +19,7 @@ Resque.redis = $redis
 # set `VERBOSE=true` when running the tests to view resques log output.
 module Resque
   class Worker
+    attr_accessor :start_lag
 
     def log_with_severity(severity, msg)
       if ENV['VERBOSE']
@@ -27,6 +28,18 @@ module Resque
       end
     end
 
+    def report_failed_job(job, exception)
+      $SEQ_WRITER.print "failed_job_#{exception.class.name.downcase.gsub('::', '_')}\n"
+    end
+
+    def fork_hijacked?
+      if @release_fork_limit
+        if start_lag
+          sleep start_lag
+        end
+      end
+      @release_fork_limit
+    end
   end
 end
 


### PR DESCRIPTION
Previously, a child receiving TERM would immediately raise an exception. If this happened during or after `Resque.reserve` but before the job started, the exception would not be handled like a job failure. As a result, resque-retry never sees the failure and the job is lost permanently.

This changes the SIGTERM handler (copied from Resque) to check to see whether a job is currently running. If so, TermException is raised (the current behavior). If not, `shutdown` is called. If this is between `Resque.reserve` and performing the job, flow should very quickly reach `perform_with_multi_job_forks`. A check has been added there which, if shutdown has been triggered, will immediately fail it rather than running it. After this, an orderly shutdown will be performed by Resque.

A more complete solution for this would probably require rewriting parts of Resque itself to use LMOVE rather than LPOP, but this should bring the risk of job loss on par with vanilla Resque.